### PR TITLE
전체 렌더링 시 current stroke 제외 및 드로잉 로직 단순화

### DIFF
--- a/GuestBook/DrawController.cpp
+++ b/GuestBook/DrawController.cpp
@@ -17,7 +17,6 @@ namespace {
 
 void DrawController::DrawStrokes(HDC hdc,
     const std::vector<Stroke>& strokes,
-    const Stroke current,
     int penWidth,
     COLORREF color
     )
@@ -37,20 +36,6 @@ void DrawController::DrawStrokes(HDC hdc,
         SelectObject(hdc, oldPen);
         DeleteObject(pen);
     }
-    if (!current.points.empty()) { ///현재 마우스를 눌러서 그리는 점의 정보
-        LOGBRUSH style = {};
-        style.lbStyle = BS_SOLID;
-        style.lbColor = current.color;
-
-        HPEN pen = ExtCreatePen(PS_GEOMETRIC | current.penStyle, current.penWidth, &style, 0, nullptr);
-        HGDIOBJ oldPen = SelectObject(hdc, pen);
-        HGDIOBJ oldBrush = SelectObject(hdc, GetStockObject(HOLLOW_BRUSH));
-        DrawPointsLine(hdc, current.points);
-        SelectObject(hdc, oldBrush);
-        SelectObject(hdc, oldPen);
-        DeleteObject(pen);
-    }
-
 }
 
 void DrawController::DrawLatestStroke(HDC hdc, const Stroke& stroke, int penWidth, COLORREF color) { /// 점과 점을 이어주는 역할

--- a/GuestBook/DrawController.h
+++ b/GuestBook/DrawController.h
@@ -7,7 +7,6 @@ class DrawController {
 public:
     void DrawStrokes(HDC hdc,
       const std::vector<Stroke>& stroke,
-      const Stroke current,
       int penWidth = 2,
       COLORREF color = RGB(30, 30, 30));
 

--- a/GuestBook/DrawWindow.cpp
+++ b/GuestBook/DrawWindow.cpp
@@ -86,12 +86,11 @@
 		const auto current = strokeCtrl.Current();
 
 		if (isReplaying) {
-			drawCtrl.DrawStrokes(backBuffer->dc(), strokes, current ? *current : Stroke(), penWidth, selectedColor);
+			drawCtrl.DrawStrokes(backBuffer->dc(), strokes, penWidth, selectedColor);
 		}
 		else {
 			drawCtrl.DrawStrokes(backBuffer->dc(),
 				strokeCtrl.Strokes(),
-				strokeCtrl.Current() ? *strokeCtrl.Current() : Stroke(),
 				penWidth, selectedColor);
 		}
 		backBuffer->DrawBufferToScreen(hdc);


### PR DESCRIPTION
DrawController::DrawStrokes에서 current stroke 렌더링을 제거했습니다.
DrawWindow::OnPaint에서 current 관련 인자 제거로 전체 그리기는 strokes로만 렌더링하도록 수정하였습니다.
실시간 드로잉은 기존처럼 DrawLatestStroke에서 처리되는 구조 그대로 유지하여 수정사항 없습니다.