### PR TITLE
선 굵기 깨짐 문제 수정 (dirty rect 제거)

### DIFF
--- a/GuestBook/BackBuffer.cpp
+++ b/GuestBook/BackBuffer.cpp
@@ -36,15 +36,6 @@ void BackBuffer::DrawBufferToScreen(HDC dst, int x, int y) const {
 	BitBlt(dst, x, y, width, height, memdc, 0, 0, SRCCOPY);
 }
 
-/// 실시간 그리기용 부분 복사
-void BackBuffer::DrawDirtyBufferToScreen(HDC dst, const RECT& dirty, int x, int y) const {
-	if (!memdc || !dst || (width <= 0) || (height <= 0)) return;
-	int w = dirty.right - dirty.left;
-	int h = dirty.bottom - dirty.top; 
-	BitBlt(dst, dirty.left + x, dirty.top + y, w, h, memdc, dirty.left, dirty.top,SRCCOPY);
-}
-
-
 void BackBuffer::ReleaseBuffer() {
 	if (memdc) {
 		if (old) {

--- a/GuestBook/BackBuffer.h
+++ b/GuestBook/BackBuffer.h
@@ -12,7 +12,6 @@ public:
 	void CreateBuffer(HDC refDC, int w, int h);
 	void ClearBuffer(const RECT& rc) const;
 	void DrawBufferToScreen(HDC dst, int x = 0, int y = 0) const;
-  void DrawDirtyBufferToScreen(HDC dst, const RECT& dirty, int x = 0, int y = 0) const;
 	void ReleaseBuffer();
 
 	HDC dc() const { return memdc; }

--- a/GuestBook/DrawWindow.cpp
+++ b/GuestBook/DrawWindow.cpp
@@ -115,17 +115,8 @@
 				
 				drawCtrl.DrawLatestStroke(backBuffer->dc(), *cur, currentPenWidth, erasing ? RGB(255,255,255) : selectedColor);
 
-				/// dirty rect
-				const Point& p1 = cur->points[cur->points.size() - 2];
-				const Point& p2 = cur->points.back();
-				RECT dirty = { min(p1.x, p2.x) - penWidth,
-							   min(p1.y, p2.y) - penWidth,
-							   max(p1.x, p2.x) + penWidth,
-							   max(p1.y, p2.y) + penWidth };
-
-				/// dirty 
 				HDC hdc = GetDC(hwnd);
-				backBuffer->DrawDirtyBufferToScreen(hdc, dirty);
+				backBuffer->DrawBufferToScreen(hdc);
 				ReleaseDC(hwnd, hdc);
 			}
 		}


### PR DESCRIPTION
DrawWindow::OnMouseMove에서 부분 갱신(dirty rect) 방식으로 인해 선 굵기가 일정하지 않게 보이던 문제를 개선했습니다.

BackBuffer 내부의 dirty rect 계산 및 적용 로직 제거하고,
 DrawWindow::OnMouseMove 시 전체 redraw로 변경하여 그리기 중에도 일정한 선 두께가 유지되도록 하였습니다.