### PR TITLE
feat: 지우기 토글 시 이전 색상 복원 구현

### DIFF
--- a/GuestBook/Application.h
+++ b/GuestBook/Application.h
@@ -87,7 +87,15 @@ public:
         });
         btnCtrl.RegisterHandler(ERASE, [&]() {
         ///    MessageBox(nullptr, L"지우기 버튼", L"TOOL창", MB_OK);
-            drawWindow.setSelectedColor(RGB(255, 255, 255));
+
+            if (drawWindow.GetErasing()) {
+                drawWindow.setSelectedColor(drawWindow.lastSelectedColor);
+            }
+            else {
+                drawWindow.lastSelectedColor = drawWindow.GetSelectedColor();
+                drawWindow.setSelectedColor(RGB(255, 255, 255));
+            } 
+            drawWindow.setErasing(); 
         });
         btnCtrl.RegisterHandler(BRUSH, [&]() {
             penBox.setDrawWindow(&drawWindow);

--- a/GuestBook/DrawWindow.cpp
+++ b/GuestBook/DrawWindow.cpp
@@ -99,7 +99,7 @@
 	void DrawWindow::OnLButtonDown(int x, int y, WPARAM) {
 		if (isReplaying) return;
 		SetCapture(hwnd);
-		COLORREF color = erasing ? RGB(255, 255, 255) : selectedColor;
+		COLORREF color = selectedColor;
 
 		strokeCtrl.Begin(x, y, color, currentPenStyle, currentPenWidth);
 }
@@ -113,7 +113,7 @@
 			const Stroke* cur = strokeCtrl.Current();
 			if (cur && cur->points.size() >= 2) {
 				
-				drawCtrl.DrawLatestStroke(backBuffer->dc(), *cur, currentPenWidth, erasing ? RGB(255,255,255) : selectedColor);
+				drawCtrl.DrawLatestStroke(backBuffer->dc(), *cur, currentPenWidth, selectedColor);
 
 				HDC hdc = GetDC(hwnd);
 				backBuffer->DrawBufferToScreen(hdc);

--- a/GuestBook/DrawWindow.h
+++ b/GuestBook/DrawWindow.h
@@ -20,20 +20,23 @@ public:
     bool Create(HWND parentHwnd, HINSTANCE hInstance);
     HWND GetHwnd() const { return hwnd; }
     HDC GetMemDc() const; 
+    BOOL GetErasing() const { return erasing;  }
+    COLORREF GetSelectedColor() const { return selectedColor; }
     const std::vector<Stroke>& GetDrawnStrokes() const { return strokeCtrl.Strokes(); }
     void SetStrokes(std::vector<Stroke> strokes) { strokeCtrl.setStrokes(strokes); }
     void SetPenStyle(int PenNum); /// 브러쉬 컨트롤러 다이얼로그에서 받은 넘버
     void SetPenWidth(int PenWidth); /// 브러쉬 컨트롤러 다이얼로그에서 받은 두께
-/// const std::vector<Stroke>& GetDrawnStrokes() const { return strokeCtrl.Strokes(); }
+
 
     void SetToolWindow(ToolWindow* tool) { toolWindow = tool; }
     void setSelectedColor(COLORREF color) { this->selectedColor = color; }
     void setBuffer(BackBuffer& buffer) { backBuffer  = &buffer; }
-    void setErasing(bool erase) { erasing = erase; }
+    void setErasing() { erasing = !erasing; }
     void setReplaying(bool isReplaying) { this->isReplaying = isReplaying;  }
     void SetApplication(Application* a) { app = a; }
     void ClearAll();
 
+    COLORREF lastSelectedColor = RGB(0, 0, 0);
 
 private:
     LRESULT HandleMessage(UINT msg, WPARAM wParam, LPARAM lParam);
@@ -59,5 +62,5 @@ private:
     bool erasing = false;
     bool isReplaying = false;
     int currentPenStyle = PS_SOLID;
-    int currentPenWidth = 1;
+    int currentPenWidth = 5;
 };


### PR DESCRIPTION
지우개 버튼 클릭 시 현재 펜 색상을 저장하고 흰색으로 전환,
다시 클릭 시 저장된 색상으로 복원되는 기능을 추가하였습니다.