### PR TITLE
리플레이 시 strokes 데이터 삭제로 저장/불러오기 시 빈 화면 문제 수정

### DIFF
--- a/GuestBook/Application.h
+++ b/GuestBook/Application.h
@@ -63,7 +63,8 @@ public:
                 HWND hDrawWnd = drawWindow.GetHwnd();
                 vector<Stroke> strokesCopy = drawWindow.GetDrawnStrokes();
 
-                drawWindow.ClearAll();
+                //drawWindow.ClearAll();
+                drawWindow.ClearScreenOnly();
 
                 drawWindow.setReplaying(true);
 
@@ -90,10 +91,13 @@ public:
 
             if (drawWindow.GetErasing()) {
                 drawWindow.setSelectedColor(drawWindow.lastSelectedColor);
+                drawWindow.SetPenStyle(penBox.LastPenNum);
             }
             else {
                 drawWindow.lastSelectedColor = drawWindow.GetSelectedColor();
+                penBox.LastPenNum = penBox.PenNum;
                 drawWindow.setSelectedColor(RGB(255, 255, 255));
+                drawWindow.SetPenStyle(PS_SOLID);
             } 
             drawWindow.setErasing(); 
         });

--- a/GuestBook/DrawWindow.cpp
+++ b/GuestBook/DrawWindow.cpp
@@ -147,6 +147,16 @@
 		InvalidateRect(hwnd, nullptr, TRUE);
 	}
 
+	void DrawWindow::ClearScreenOnly() {
+		RECT rc;
+		GetClientRect(hwnd, &rc);
+		if (backBuffer) {
+			backBuffer->ClearBuffer(rc);
+		}
+
+		InvalidateRect(hwnd, nullptr, TRUE);
+	}
+
 	HDC DrawWindow::GetMemDc() const { return backBuffer ? backBuffer->dc() : nullptr; }
 
 	void DrawWindow::SetPenStyle(int PenNum) { /// ���̾�α� ���� ��ư �ѹ����� �� ����

--- a/GuestBook/DrawWindow.h
+++ b/GuestBook/DrawWindow.h
@@ -35,6 +35,7 @@ public:
     void setReplaying(bool isReplaying) { this->isReplaying = isReplaying;  }
     void SetApplication(Application* a) { app = a; }
     void ClearAll();
+    void ClearScreenOnly();
 
     COLORREF lastSelectedColor = RGB(0, 0, 0);
 

--- a/GuestBook/PenController.h
+++ b/GuestBook/PenController.h
@@ -11,6 +11,8 @@ public:
 	void setDrawWindow(DrawWindow* dw) { drawWindow = dw; };
 	int PenNum = 0;
 	int PenWidth = 1;
+	int LastPenNum;
+	int LastPenWidth; 
 
 private:
 	HINSTANCE hInstance = nullptr;


### PR DESCRIPTION
리플레이 시 ClearAll()로 strokes 데이터가 삭제되어 저장/불러오기 시 빈 화면이 출력되는 문제가 있어, 리플레이 과정에서는 화면만 초기화하도록 ClearScreenOnly()를 도입하고, ClearAll()은 전체 지우기에서만 사용하도록 분리했습니다.

리플레이 후 저장/불러오기 정상 동작하며 전체 지우기 기능은 그대로 유지됩니다.